### PR TITLE
Bump Siddhi version, fix test cases and update release version

### DIFF
--- a/component/pom.xml
+++ b/component/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.extension.siddhi.execution.map</groupId>
         <artifactId>siddhi-execution-map-parent</artifactId>
-        <version>4.0.20-SNAPSHOT</version>
+        <version>4.1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/component/src/test/java/org/wso2/extension/siddhi/execution/map/CreateFromJSONFunctionExtensionTestCase.java
+++ b/component/src/test/java/org/wso2/extension/siddhi/execution/map/CreateFromJSONFunctionExtensionTestCase.java
@@ -29,7 +29,7 @@ import org.wso2.siddhi.core.SiddhiAppRuntime;
 import org.wso2.siddhi.core.SiddhiManager;
 import org.wso2.siddhi.core.event.Event;
 import org.wso2.siddhi.core.exception.SiddhiAppCreationException;
-import org.wso2.siddhi.core.executor.function.FunctionExecutor;
+import org.wso2.siddhi.core.stream.StreamJunction;
 import org.wso2.siddhi.core.stream.input.InputHandler;
 import org.wso2.siddhi.core.stream.output.StreamCallback;
 import org.wso2.siddhi.core.util.EventPrinter;
@@ -153,7 +153,7 @@ public class CreateFromJSONFunctionExtensionTestCase {
     @Test
     public void testCreateFromJSONFunctionExtension4() throws InterruptedException {
         log.info("CreateFromJSONFunctionExtension TestCase with test string data format");
-        log = Logger.getLogger(FunctionExecutor.class);
+        log = Logger.getLogger(StreamJunction.class);
         UnitTestAppender appender = new UnitTestAppender();
         log.addAppender(appender);
         SiddhiManager siddhiManager = new SiddhiManager();
@@ -176,7 +176,7 @@ public class CreateFromJSONFunctionExtensionTestCase {
     @Test
     public void testCreateFromJSONFunctionExtension5() throws InterruptedException {
         log.info("CreateFromJSONFunctionExtension TestCase with test data should be a string");
-        log = Logger.getLogger(FunctionExecutor.class);
+        log = Logger.getLogger(StreamJunction.class);
         UnitTestAppender appender = new UnitTestAppender();
         log.addAppender(appender);
         SiddhiManager siddhiManager = new SiddhiManager();

--- a/component/src/test/java/org/wso2/extension/siddhi/execution/map/CreateFromXMLFunctionExtensionTestCase.java
+++ b/component/src/test/java/org/wso2/extension/siddhi/execution/map/CreateFromXMLFunctionExtensionTestCase.java
@@ -29,7 +29,7 @@ import org.wso2.siddhi.core.SiddhiAppRuntime;
 import org.wso2.siddhi.core.SiddhiManager;
 import org.wso2.siddhi.core.event.Event;
 import org.wso2.siddhi.core.exception.SiddhiAppCreationException;
-import org.wso2.siddhi.core.executor.function.FunctionExecutor;
+import org.wso2.siddhi.core.stream.StreamJunction;
 import org.wso2.siddhi.core.stream.input.InputHandler;
 import org.wso2.siddhi.core.stream.output.StreamCallback;
 import org.wso2.siddhi.core.util.EventPrinter;
@@ -181,7 +181,7 @@ public class CreateFromXMLFunctionExtensionTestCase {
     @Test
     public void testCreateFromXMLFunctionExtension4() throws InterruptedException {
         log.info("CreateFromXMLFunctionExtension TestCase with test string data has xml format");
-        log = Logger.getLogger(FunctionExecutor.class);
+        log = Logger.getLogger(StreamJunction.class);
         UnitTestAppender appender = new UnitTestAppender();
         log.addAppender(appender);
         SiddhiManager siddhiManager = new SiddhiManager();
@@ -208,7 +208,7 @@ public class CreateFromXMLFunctionExtensionTestCase {
     @Test
     public void testCreateFromXMLFunctionExtension5() throws InterruptedException {
         log.info("CreateFromXMLFunctionExtension TestCase with test data is to be a string");
-        log = Logger.getLogger(FunctionExecutor.class);
+        log = Logger.getLogger(StreamJunction.class);
         UnitTestAppender appender = new UnitTestAppender();
         log.addAppender(appender);
         SiddhiManager siddhiManager = new SiddhiManager();

--- a/component/src/test/java/org/wso2/extension/siddhi/execution/map/GetFunctionExtensionTestCase.java
+++ b/component/src/test/java/org/wso2/extension/siddhi/execution/map/GetFunctionExtensionTestCase.java
@@ -28,7 +28,7 @@ import org.wso2.siddhi.core.SiddhiAppRuntime;
 import org.wso2.siddhi.core.SiddhiManager;
 import org.wso2.siddhi.core.event.Event;
 import org.wso2.siddhi.core.exception.SiddhiAppCreationException;
-import org.wso2.siddhi.core.executor.function.FunctionExecutor;
+import org.wso2.siddhi.core.stream.StreamJunction;
 import org.wso2.siddhi.core.stream.input.InputHandler;
 import org.wso2.siddhi.core.stream.output.StreamCallback;
 import org.wso2.siddhi.core.util.EventPrinter;
@@ -175,7 +175,7 @@ public class GetFunctionExtensionTestCase {
     @Test
     public void testGetFunctionExtension4() throws InterruptedException {
         log.info("GetFunctionExtension TestCase with test first attribute value must be of type java.util.Map");
-        log = Logger.getLogger(FunctionExecutor.class);
+        log = Logger.getLogger(StreamJunction.class);
         UnitTestAppender appender = new UnitTestAppender();
         log.addAppender(appender);
         SiddhiManager siddhiManager = new SiddhiManager();

--- a/component/src/test/java/org/wso2/extension/siddhi/execution/map/ToJSONFunctionExtensionTestCase.java
+++ b/component/src/test/java/org/wso2/extension/siddhi/execution/map/ToJSONFunctionExtensionTestCase.java
@@ -32,7 +32,7 @@ import org.wso2.siddhi.core.SiddhiAppRuntime;
 import org.wso2.siddhi.core.SiddhiManager;
 import org.wso2.siddhi.core.event.Event;
 import org.wso2.siddhi.core.exception.SiddhiAppCreationException;
-import org.wso2.siddhi.core.executor.function.FunctionExecutor;
+import org.wso2.siddhi.core.stream.StreamJunction;
 import org.wso2.siddhi.core.stream.input.InputHandler;
 import org.wso2.siddhi.core.stream.output.StreamCallback;
 import org.wso2.siddhi.core.util.EventPrinter;
@@ -192,7 +192,7 @@ public class ToJSONFunctionExtensionTestCase {
     @Test
     public void testToJSONFunctionExtension4() throws InterruptedException {
         log.info("ToJSONFunctionExtension TestCase with data should be a Map string format");
-        log = Logger.getLogger(FunctionExecutor.class);
+        log = Logger.getLogger(StreamJunction.class);
         UnitTestAppender appender = new UnitTestAppender();
         log.addAppender(appender);
         SiddhiManager siddhiManager = new SiddhiManager();

--- a/component/src/test/java/org/wso2/extension/siddhi/execution/map/ToXMLFunctionExtensionTestCase.java
+++ b/component/src/test/java/org/wso2/extension/siddhi/execution/map/ToXMLFunctionExtensionTestCase.java
@@ -32,7 +32,7 @@ import org.wso2.siddhi.core.SiddhiAppRuntime;
 import org.wso2.siddhi.core.SiddhiManager;
 import org.wso2.siddhi.core.event.Event;
 import org.wso2.siddhi.core.exception.SiddhiAppCreationException;
-import org.wso2.siddhi.core.executor.function.FunctionExecutor;
+import org.wso2.siddhi.core.stream.StreamJunction;
 import org.wso2.siddhi.core.stream.input.InputHandler;
 import org.wso2.siddhi.core.stream.output.StreamCallback;
 import org.wso2.siddhi.core.util.EventPrinter;
@@ -374,7 +374,7 @@ public class ToXMLFunctionExtensionTestCase {
     @Test
     public void testToXMLFunctionExtension6() throws InterruptedException {
         log.info("ToXMLFunctionExtension TestCase with test data should be Map string format  ");
-        log = Logger.getLogger(FunctionExecutor.class);
+        log = Logger.getLogger(StreamJunction.class);
         UnitTestAppender appender = new UnitTestAppender();
         log.addAppender(appender);
         SiddhiManager siddhiManager = new SiddhiManager();
@@ -399,7 +399,7 @@ public class ToXMLFunctionExtensionTestCase {
     @Test
     public void testCreateFromXMLFunctionExtension5() throws InterruptedException {
         log.info("CreateFromXMLFunctionExtension TestCase with test Object[] data should be string format");
-        log = Logger.getLogger(FunctionExecutor.class);
+        log = Logger.getLogger(StreamJunction.class);
         UnitTestAppender appender = new UnitTestAppender();
         log.addAppender(appender);
         SiddhiManager siddhiManager = new SiddhiManager();

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.wso2.extension.siddhi.execution.map</groupId>
     <artifactId>siddhi-execution-map-parent</artifactId>
-    <version>4.0.20-SNAPSHOT</version>
+    <version>4.1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Siddhi Execution Extension - Map Aggregator Pom</name>
 
@@ -45,7 +45,7 @@
     </profiles>
 
     <properties>
-        <siddhi.version>4.2.17</siddhi.version>
+        <siddhi.version>4.4.8</siddhi.version>
         <siddhi.import.version.range>[4.1, 5.0)</siddhi.import.version.range>
         <log4j.version>1.2.17.wso2v1</log4j.version>
         <org.json.wso2.version>2.0.0.wso2v1</org.json.wso2.version>


### PR DESCRIPTION
## Purpose
> Upgraded siddhi-execution-map extension to be compatible with latest (v4.4.8) Siddhi version.
> Fixed test failures.
> Extension version is bumped to 4.1.0

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
